### PR TITLE
Configuration via env var, throw 500s on error, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
     * gateway: 0.0.0.0
 
 ## Use
-1. Share an album with a URL that doesn't expire
-2. Browse to the share url with f12 (network debugging)
-3. Open an individual image and look for the file load
-4. `/api/asset/thumbnail/3c57228c-8262-4e14-998b-c10755413e6d?format=WEBP&key=<this-shares-access-key>`
+1. Share an album with a URL that doesn't expire. This contains the access key for the share (share access key).
+2. Get the guid for that share (your-share-guid-from-api):
+   1. `curl -L -X GET https://my-immich.example.com/api/shared-link/ -H 'Accept: application/json' -H 'x-api-key: yourapikeyhere'`
 
-Set your request url from your frame to 
-`https://url/path?shareId=<your-share-id-from-api>&accessKey=<this-shares-access-key>&user=<user-set-in-python-script>`
+Set your request url from your frame to the below. The first 2 values from from the above steps, the username is the username you'll set in the environment variables.
+
+`https://url/path?shareId=<your-share-guid-from-api>&accessKey=<share-access-key>&user=<user-set-in-python-script>`
 
 
 ### Run the docker container
@@ -32,6 +32,16 @@ If using more than one user, set these additional environment variables
 export USERNAME_2=some-username
 export API_KEY_2=12345
 ```
+
+If your proxy interacts with immich API directly, but you want to redirect users to a different url:
+
+For example, you might run immich and immich-python-slideshow on the same host and want to avoid extra auth added by nginx in front of immich.
+
+```
+# be sure to include the trailing slash for this one
+export IMMICH_API_URL=https://my-immich-host.lan:2283/
+```
+
 
 Start the container
 ```

--- a/README.md
+++ b/README.md
@@ -2,20 +2,38 @@
 
 ## Setup
 1. Create API Key in Immich
-1. Update the redirect-multiuser.py with your API key
-- Replace the \<user\> and \<API KEY\>
-- Replace \<https://url/here> with your url
-
-1. Update the docker-compose.yml
-- subnet: 0.0.0.0/0
-- ip_range: 0.0.0.0/0
-- gateway: 0.0.0.0
+2. Update the docker-compose.yml
+    * subnet: 0.0.0.0/0
+    * ip_range: 0.0.0.0/0
+    * gateway: 0.0.0.0
 
 ## Use
 1. Share an album with a URL that doesn't expire
 2. Browse to the share url with f12 (network debugging)
-3. Open an indivudial image and look for the file load
+3. Open an individual image and look for the file load
 4. `/api/asset/thumbnail/3c57228c-8262-4e14-998b-c10755413e6d?format=WEBP&key=<this-shares-access-key>`
 
 Set your request url from your frame to 
 `https://url/path?shareId=<your-share-id-from-api>&accessKey=<this-shares-access-key>&user=<user-set-in-python-script>`
+
+
+### Run the docker container
+
+Set required environment variables:
+```
+# be sure to include the trailing slash for this one
+export IMMICH_URL=https://my-immich.example.com/
+export USERNAME_1=some-username
+export API_KEY_1=12345
+```
+
+If using more than one user, set these additional environment variables
+```
+export USERNAME_2=some-username
+export API_KEY_2=12345
+```
+
+Start the container
+```
+docker compose up
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 version: "3"
 
-# More info at https://github.com/pi-hole/docker-pi-hole/ and https://docs.pi-hole.net/
 services:
   immich-redirect-proxy-nick:
     container_name: immich-redirect-proxy
@@ -9,6 +8,11 @@ services:
       - "8000:8000/tcp"
     environment:
       TZ: 'America/Chicago'
+      IMMICH_URL: '${IMMICH_URL}'
+      USERNAME_1: '${USERNAME_1}'
+      API_KEY_1: '${API_KEY_1}'
+      USERNAME_2: '${USERNAME_2:-unused}'
+      API_KEY_2: '${API_KEY_2:-unused}'
     restart: unless-stopped
     volumes:
       - ./redirect-multiuser.py:/redirect.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     environment:
       TZ: 'America/Chicago'
       IMMICH_URL: '${IMMICH_URL}'
+      IMMICH_API_URL: '${IMMICH_API_URL:-unset}'
       USERNAME_1: '${USERNAME_1}'
       API_KEY_1: '${API_KEY_1}'
       USERNAME_2: '${USERNAME_2:-unused}'

--- a/redirect-multiuser.py
+++ b/redirect-multiuser.py
@@ -1,102 +1,118 @@
 #!/usr/bin/env python3
 
-import sys, requests, random, json
+import os, requests, random, json
 from urllib.parse import urlparse
 from urllib.parse import parse_qs
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
-def get_Images(photo,shareId,user):
-  url = "<https://url/here>api/shared-link/"+shareId
-  payload={}
-  if user == "<user>":
-    headers = {
-      'Accept': 'application/json',
-      'x-api-key': '<apikey>',
-      'Connection': 'close'
-    }
-  elif user == "<user>" or "<user>":
-    headers = {
-      'Accept': 'application/json',
-      'x-api-key': '<apikey>',
-      'Connection': 'close'
-    }
-  # else:
-    # print("failed",flush=True)
-  response = requests.get(url, headers=headers, data=payload)
-  y = json.loads(response.text)
-  for x in y["assets"]:
-    allowlist = ("jpg", "png")
-    if x["originalPath"].lower().endswith(allowlist):
-      try:
-        photo[user].append(x["id"])
-      except KeyError:
-        photo[user] = [(x["id"])]
-    else:
-      print("Not an allowed filetype "+x["originalPath"],flush=True)
-      print("Not an allowed filetype "+x["id"]+" "+str(allowlist),flush=True)
-  response.close()
-  return photo
+IMMICH_URL = os.environ["IMMICH_URL"]
 
-def check_photos(photo,shareId,user):
-  try:
-    if len(photo[user]) < 2:
-      print("Getting images for "+user,flush=True)
-      get_Images(photo,shareId,user)
+USERNAME_1 = os.environ['USERNAME_1']
+API_KEY_1 = os.environ['API_KEY_1']
+
+USERNAME_2 = os.environ['USERNAME_2']
+API_KEY_2 = os.environ['API_KEY_2']
+
+
+def get_images(photo, shareId, user):
+    url = f"{IMMICH_URL}api/shared-link/" + shareId
+    payload = {}
+    if user == USERNAME_1:
+        headers = {
+            'Accept': 'application/json',
+            'x-api-key': '<apikey>',
+            'Connection': 'close'
+        }
+    elif user == USERNAME_2:
+        headers = {
+            'Accept': 'application/json',
+            'x-api-key': '<apikey>',
+            'Connection': 'close'
+        }
+    # else:
+    # print("failed",flush=True)
+    response = requests.get(url, headers=headers, data=payload)
+    y = json.loads(response.text)
+    for x in y["assets"]:
+        allowlist = ("jpg", "png")
+        if x["originalPath"].lower().endswith(allowlist):
+            try:
+                photo[user].append(x["id"])
+            except KeyError:
+                photo[user] = [(x["id"])]
+        else:
+            print("Not an allowed filetype " + x["originalPath"], flush=True)
+            print("Not an allowed filetype " + x["id"] + " " + str(allowlist), flush=True)
+    response.close()
     return photo
-  except KeyError:
-    print("Key Error. Getting images for "+user,flush=True)
-    get_Images(photo,shareId,user)
-    return photo
+
+
+def check_photos(photo, shareId, user):
+    try:
+        if len(photo[user]) < 2:
+            print("Getting images for " + user, flush=True)
+            get_images(photo, shareId, user)
+        return photo
+    except KeyError:
+        print("Key Error. Getting images for " + user, flush=True)
+        get_images(photo, shareId, user)
+        return photo
+
 
 def get_query_field(url, field):
-  try:
-      return parse_qs(urlparse(url).query)[field][0]
-  except KeyError:
-      return []
-  
-def status(photo,id,user):
-  print(id,flush=True)
-  print(len(photo[user]),flush=True)
+    try:
+        return parse_qs(urlparse(url).query)[field][0]
+    except KeyError:
+        return []
+
+
+def status(photo, id, user):
+    print(id, flush=True)
+    print(len(photo[user]), flush=True)
+
 
 class Redirect(BaseHTTPRequestHandler):
-  def do_GET(self):
+    def do_GET(self):
 
-    url = "<https://url/here>"+self.path
-    shareId = get_query_field(url,'shareId')
-    accessKey = get_query_field(url,'accessKey')
-    user = get_query_field(url,'user')
-    reset = get_query_field(url,'reset')
+        url = f"{IMMICH_URL}" + self.path
+        share_id = get_query_field(url, 'shareId')
+        access_key = get_query_field(url, 'accessKey')
+        user = get_query_field(url, 'user')
+        reset = get_query_field(url, 'reset')
 
-    if reset:
-      print("Resetting...Getting images.",flush=True)
-      get_Images(photo,shareId,user)
-      # print(len(photo[user]),flush=True)
+        if reset:
+            print("Resetting...Getting images.", flush=True)
+            get_images(photo, share_id, user)
+            # print(len(photo[user]),flush=True)
 
-    try:
-      if not accessKey:
-        self.send_response(400)
-      else:
-        if photo[user]:
-          id = random.choice(photo[user])
-          status(photo,id,user)
-          print("<https://url/here>api/asset/file/"+id+"?isThumb=false&isWeb=true&key="+accessKey)
-          photo[user].remove(id)
-          self.send_response(302)
-          self.send_header('Location', "<https://url/here>api/asset/file/"+id+"?isThumb=false&isWeb=true&key="+accessKey)
-          self.end_headers()
-        else:
-          check_photos(photo,shareId,user)
-    except KeyError:
-      # print("Getting images.",flush=True)
-      get_Images(photo,shareId,user)
-      print("KeyError",flush=True)
-      id = random.choice(photo[user])
-      photo[user].remove(id)
-      self.send_response(302)
-      self.send_header('Location', "<https://url/here>api/asset/file/"+id+"?isThumb=false&isWeb=true&key="+accessKey)
-      self.end_headers()
-      return
+        try:
+            if not access_key:
+                self.send_response(400)
+            else:
+                if photo[user]:
+                    id = random.choice(photo[user])
+                    status(photo, id, user)
+                    print(f"{IMMICH_URL}api/asset/file/" + id + "?isThumb=false&isWeb=true&key=" + access_key)
+                    photo[user].remove(id)
+                    self.send_response(302)
+                    self.send_header('Location',
+                                     f"{IMMICH_URL}api/asset/file/" + id + "?isThumb=false&isWeb=true&key=" + access_key)
+                    self.end_headers()
+                else:
+                    check_photos(photo, share_id, user)
+        except KeyError:
+            # print("Getting images.",flush=True)
+            get_images(photo, share_id, user)
+            print("KeyError", flush=True)
+            id = random.choice(photo[user])
+            photo[user].remove(id)
+            self.send_response(302)
+            self.send_header('Location',
+                             f"{IMMICH_URL}api/asset/file/" + id + "?isThumb=false&isWeb=true&key=" + access_key)
+            self.end_headers()
+            return
+
 
 photo = {}
-print("ready",flush=True)
+print("ready", flush=True)
 HTTPServer(("", int(8000)), Redirect).serve_forever()


### PR DESCRIPTION
Thanks for this script, I've been experimenting with it and it works great! I made some improvements along the way:

* Support separate API and redirect urls
  * My redirected urls have extra auth in front of them, while I can access the api with just immich auth since it's on the same host
* Throw 500s on error occurring instead of dropping connection
* Reformat code and extract a reused method or two
* Move configuration to environment variables
* Update the readme to support the environment variables and show how to get the share guid